### PR TITLE
Fix observation_test bugs

### DIFF
--- a/tests/observation_test.py
+++ b/tests/observation_test.py
@@ -81,7 +81,9 @@ class FixedPlayPolicy(network_policy.Policy):
     return action_output
 
 
-class ObservationTest(absltest.TestCase, metaclass=abc.ABCMeta):
+class ObservationTest(absltest.TestCase):
+
+  __metaclass__ = abc.ABCMeta
 
   @abc.abstractmethod
   def get_diplomacy_state(self) -> diplomacy_state.DiplomacyState:

--- a/tests/observation_test.py
+++ b/tests/observation_test.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, Sequence, Tuple
 from absl.testing import absltest
 import numpy as np
 import tree
+import dill
 
 from diplomacy.environment import diplomacy_state
 from diplomacy.environment import game_runner

--- a/tests/observation_test.py
+++ b/tests/observation_test.py
@@ -228,3 +228,6 @@ class ObservationTest(absltest.TestCase, metaclass=abc.ABCMeta):
     tree.map_structure(np.testing.assert_array_equal,
                        self.get_reference_legal_actions(),
                        trajectory.legal_actions)
+
+if __name__ == '__main__':
+  absltest.main()


### PR DESCRIPTION
This PR:
- Calls absltest.main() in observation_test.py's main function
- Imports dill for using sample implementations of abstract methods
- Fixes instantiation type error caused by passing the metaclass keyword

It does not:
- Fix the attribute error caused by calling get_diplomacy_state() [The function must be implemented and it is not clear how to do it, help from maintainers is required]

To run the tests:
`python -m diplomacy.tests.observation_test`